### PR TITLE
make kubectl more flexible

### DIFF
--- a/templates/job-create-gpg.yaml
+++ b/templates/job-create-gpg.yaml
@@ -50,7 +50,8 @@ spec:
               PRIVATE_SERVERKEY="$(gpg --homedir $GNUPGHOME --armor --export-secret-keys $key_email | base64 -w0)"
               PUBLIC_SERVERKEY="$(gpg --homedir $GNUPGHOME --armor --export $key_email | base64 -w0)"
 
-              curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+              kubectlDownload=${KUBECTL_DOWNLOAD_CMD:-'curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"'}
+              eval $kubectlDownload
               chmod +x kubectl
               ./kubectl patch secret {{ $Name }}-sec-gpg --type='json' -p='[{"op": "replace", "path" : "/data/serverkey_private.asc", "value" : '"${PRIVATE_SERVERKEY}"'}]'
               ./kubectl patch secret {{ $Name }}-sec-gpg --type='json' -p='[{"op": "replace", "path" : "/data/serverkey.asc", "value" : '"${PUBLIC_SERVERKEY}"'}]'

--- a/values.yaml
+++ b/values.yaml
@@ -137,6 +137,8 @@ passboltEnv:
     PASSBOLT_JWT_SERVER_PEM: /var/www/passbolt/config/jwt/jwt.pem
     # -- Toggle passbolt jwt authentication
     PASSBOLT_PLUGINS_JWT_AUTHENTICATION_ENABLED: true
+    # -- Download Command for kubectl
+    KUBECTL_DOWNLOAD_CMD: curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
   secret:
     # -- Configure passbolt cake cache password
     CACHE_CAKE_DEFAULT_PASSWORD: CHANGEME


### PR DESCRIPTION
the kubectl download cmd can be set (and made flexible) as needed for firewalls, ipv4, private repositories

``` bash
helm install --namespace passbolt --create-namespace passbolt . \
	--set passboltEnv.plain.KUBECTL_DOWNLOAD_CMD="curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
```