### PR TITLE
fix: set default value for  EMAIL_TRANSPORT_DEFAULT_HOST

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -128,7 +128,7 @@ passboltEnv:
     # -- Configure passbolt default email from
     EMAIL_DEFAULT_FROM: no-reply@passbolt.local
     # -- Configure passbolt default email host
-    EMAIL_TRANSPORT_DEFAULT_HOST:
+    EMAIL_TRANSPORT_DEFAULT_HOST: 127.0.0.1
     # -- Toggle passbolt tls
     EMAIL_TRANSPORT_DEFAULT_TLS: true
     # -- Configure passbolt jwt private key path


### PR DESCRIPTION
The following messages appears when trying to deploy Passbolt with the default configuration:

```helm
Error: INSTALLATION FAILED: failed pre-install: unable to build kubernetes object for pre-install hook passbolt/templates/configmap-env.yaml: error validating "": error validating data: unknown object type "nil" in ConfigMap.data.EMAIL_TRANSPORT_DEFAULT_HOST
```
This is because the value `EMAIL_TRANSPORT_DEFAULT_HOST` on `values.yml` has no default value defined, and is rendered as `nil` by Helm. 

Setting a default value will bypass the error when deploying a chart with its default values for testing purposes. 

It solves the issue #8.