### PR TITLE
feat: add mariadb persistence options

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -38,6 +38,52 @@ mariadb:
     database: passbolt
     # -- Configure mariadb auth replicationPassword
     replicationPassword: CHANGEME
+  # -- Configure parameters for the primary instance.
+  primary:
+    # -- Configure persistence options.
+    persistence:
+      # -- Enable persistence on MariaDB primary replicas using a `PersistentVolumeClaim`. If false, use emptyDir
+      enabled: true
+      # -- Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas. When it's set the rest of persistence parameters are ignored.
+      existingClaim: ""
+      # -- Subdirectory of the volume to mount at
+      subPath: ""
+      # -- Primary persistent volume storage Class
+      storageClass: ""
+      # -- Labels for the PVC
+      labels: {}
+      # -- Primary persistent volume claim annotations
+      annotations: {}
+      # -- Primary persistent volume access Modes
+      accessModes:
+        - ReadWriteOnce
+      # -- Primary persistent volume size
+      size: 8Gi
+      # -- Selector to match an existing Persistent Volume
+      selector: {}      
+  # -- Configure parameters for the secondary instance.
+  secondary:
+    # -- Configure persistence options.
+    persistence:
+      # -- Enable persistence on MariaDB secondary replicas using a `PersistentVolumeClaim`. If false, use emptyDir
+      enabled: true
+      # -- Name of an existing `PersistentVolumeClaim` for MariaDB secondary replicas. When it's set the rest of persistence parameters are ignored.
+      existingClaim: ""
+      # -- Subdirectory of the volume to mount at
+      subPath: ""
+      # -- Secondary persistent volume storage Class
+      storageClass: ""
+      # -- Labels for the PVC
+      labels: {}
+      # -- Secondary persistent volume claim annotations
+      annotations: {}
+      # -- Secondary persistent volume access Modes
+      accessModes:
+        - ReadWriteOnce
+      # -- Secondary persistent volume size
+      size: 8Gi
+      # -- Selector to match an existing Persistent Volume
+      selector: {}      
 
 ## Passbolt configuration
 


### PR DESCRIPTION
Adding Mariadb persistence options default values is a cool idea since Helm users can easily control how much storage they can dedicate for MariaDB Primary and Secondary Pods, as well as their custom storage classes and size, also the ability to disable PVCs for testing purposes adds more usability to the project. 

The values were taken from the [official documentation](https://github.com/bitnami/charts/blob/main/bitnami/mariadb/values.yaml).