### PR TITLE
fix:  typo jwt secret values

### DIFF
--- a/templates/secret-jwt.yaml
+++ b/templates/secret-jwt.yaml
@@ -15,8 +15,8 @@ metadata:
 type: Opaque
 data:
   {{- if and ( .Values.jwtServerPrivate ) ( .Values.jwtServerPublic )}}
-  jwt.key: {{ .Values.jwtServerKeyPrivate }}
-  jwt.pem: {{ .Values.jwtServerKeyPublic }}
+  jwt.key: {{ .Values.jwtServerPrivate }}
+  jwt.pem: {{ .Values.jwtServerPublic }}
   {{- else -}}
   {{- $cert := genSelfSignedCertWithKey "" (list) (list) 3650 (genPrivateKey "rsa") }}
   jwt.key: {{ $cert.Key | b64enc }}


### PR DESCRIPTION
Following on file `values.yaml` using key `jwtServerPrivate` and `jwtServerPublic ` but on file `secret-jwt.yaml` looks typo.

this MR to fix it. Thanks...
