### PR TITLE
feat: add extraEnv and extraEnvFrom fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ To uninstall/delete the chart from your cluster:
 
 ```bash
 helm delete my-release
-````
+```
 
 The above command deletes all the kubernetes components associated with the
 chart and deletes the release.
@@ -90,7 +90,7 @@ chart and deletes the release.
 ## Requirements
 
 | Repository                                            | Name             | Version |
-|-------------------------------------------------------|------------------|---------|
+| ----------------------------------------------------- | ---------------- | ------- |
 | https://charts.bitnami.com/bitnami                    | mariadb          | 11.5.7  |
 | https://charts.bitnami.com/bitnami                    | redis            | 17.3.8  |
 | https://download.passbolt.com/charts/passbolt-library | passbolt-library | 0.2.7   |
@@ -98,7 +98,7 @@ chart and deletes the release.
 ## Values
 
 | Key                                                           | Type   | Default                                                                                                                                                                      | Description                                                                                                                                                               |
-|---------------------------------------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | affinity                                                      | object | `{}`                                                                                                                                                                         | Configure passbolt deployment affinity                                                                                                                                    |
 | app.cache.redis.enabled                                       | bool   | `true`                                                                                                                                                                       | By enabling redis the chart will mount a configuration file on /etc/passbolt/app.php That instructs passbolt to store sessions on redis and to use it as a general cache. |
 | app.cache.redis.sentinelProxy.enabled                         | bool   | `true`                                                                                                                                                                       | Inject a haproxy sidecar container configured as a proxy to redis sentinel Make sure that CACHE_CAKE_DEFAULT_SERVER is set to '127.0.0.1' to use the proxy                |
@@ -190,6 +190,8 @@ chart and deletes the release.
 | passboltEnv.secret.DATASOURCES_DEFAULT_USERNAME               | string | `"CHANGEME"`                                                                                                                                                                 | Configure passbolt default database username                                                                                                                              |
 | passboltEnv.secret.EMAIL_TRANSPORT_DEFAULT_PASSWORD           | string | `"CHANGEME"`                                                                                                                                                                 | Configure passbolt default email service password                                                                                                                         |
 | passboltEnv.secret.EMAIL_TRANSPORT_DEFAULT_USERNAME           | string | `"CHANGEME"`                                                                                                                                                                 | Configure passbolt default email service username                                                                                                                         |
+| passboltEnv.extraEnv                                          | array  | `[]`                                                                                                                                                                         | Configure passbolt extra environment variables                                                                                                                            |
+| passboltEnv.extraEnvFrom                                      | array  | `[]`                                                                                                                                                                         | Configure passbolt environment variables from existing configMaps and secrets                                                                                             |
 | podAnnotations                                                | object | `{}`                                                                                                                                                                         | Map of annotation for passbolt server pod                                                                                                                                 |
 | podSecurityContext                                            | object | `{}`                                                                                                                                                                         | Security Context configuration for passbolt server pod                                                                                                                    |
 | rbacEnabled                                                   | bool   | `true`                                                                                                                                                                       | Enable role based access control                                                                                                                                          |

--- a/templates/cronjob-proc-email.yaml
+++ b/templates/cronjob-proc-email.yaml
@@ -40,11 +40,17 @@ spec:
               env:
                 - name: DATASOURCES_DEFAULT_HOST
                   value: {{ include "passbolt.databaseServiceName" . }}
+                {{- with .Values.passboltEnv.extraEnv }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
               envFrom:
                 - configMapRef:
                     name: {{ $Name }}-cm-env
                 - secretRef:
                     name: {{ $Name }}-sec-env
+                {{- with .Values.passboltEnv.extraEnvFrom }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
               volumeMounts:
                 - name: {{ $Name }}-vol-success
                   mountPath: /tmp/pod

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -61,11 +61,17 @@ spec:
           env:
             - name: DATASOURCES_DEFAULT_HOST
               value: {{ include "passbolt.databaseServiceName" . }}
+            {{- with .Values.passboltEnv.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ $Name }}-cm-env
             - secretRef:
                 name: {{ $Name }}-sec-env
+            {{- with .Values.passboltEnv.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       containers:
         - name: {{ $fullName }}
           command:
@@ -91,11 +97,17 @@ spec:
           env:
             - name: DATASOURCES_DEFAULT_HOST
               value: {{ include "passbolt.databaseServiceName" . }}
+            {{- with .Values.passboltEnv.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ $Name }}-cm-env
             - secretRef:
                 name: {{ $Name }}-sec-env
+            {{- with .Values.passboltEnv.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             {{- if .Values.app.cache.redis.enabled }}
             - mountPath: "/etc/passbolt/app.php"

--- a/templates/job-create-gpg.yaml
+++ b/templates/job-create-gpg.yaml
@@ -72,11 +72,17 @@ spec:
           env:
             - name: DATASOURCES_DEFAULT_HOST
               value: {{ include "passbolt.databaseServiceName" . }}
+            {{- with .Values.passboltEnv.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ $Name }}-cm-env
             - secretRef:
                 name: {{ $Name }}-sec-env
+            {{- with .Values.passboltEnv.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: {{ $fullName }}-vol-success
               mountPath: /tmp/pod

--- a/values.yaml
+++ b/values.yaml
@@ -202,12 +202,13 @@ passboltEnv:
     # PASSBOLT_GPG_SERVER_KEY_FINGERPRINT:
     # -- Configure passbolt security salt.
     # SECURITY_SALT:
-  # -- Environment variables from configmaps to add to the passbolt pods
+  # -- Environment variables to add to the passbolt pods
   extraEnv: []
   # -- Environment variables from secrets or configmaps to add to the passbolt pods
   extraEnvFrom:
-    - secretRef:
-        name: passbolt-secret
+    []
+    # - secretRef:
+    #     name: passbolt-secret
 ## Passbolt deployment parameters
 
 # -- If autoscaling is disabled this will define the number of pods to run

--- a/values.yaml
+++ b/values.yaml
@@ -202,7 +202,12 @@ passboltEnv:
     # PASSBOLT_GPG_SERVER_KEY_FINGERPRINT:
     # -- Configure passbolt security salt.
     # SECURITY_SALT:
-
+  # -- Environment variables from configmaps to add to the passbolt pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the passbolt pods
+  extraEnvFrom:
+    - secretRef:
+        name: passbolt-secret
 ## Passbolt deployment parameters
 
 # -- If autoscaling is disabled this will define the number of pods to run


### PR DESCRIPTION
It would be useful to add `extraEnvFrom` to inject variables to pods from existing K8s secrets (like databse host, username, password, etc.)