### PR TITLE
feat: add email from name and email transport timeout to the plain env

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,10 @@ chart and deletes the release.
 | passboltEnv.plain.CACHE_CAKE_DEFAULT_SERVER | string | `"127.0.0.1"` | Configure passbolt cake cache server |
 | passboltEnv.plain.DEBUG | bool | `false` | Toggle passbolt debug mode |
 | passboltEnv.plain.EMAIL_DEFAULT_FROM | string | `"no-reply@passbolt.local"` | Configure passbolt default email from |
+| passboltEnv.plain.EMAIL_DEFAULT_FROM_NAME | string | `"Passbolt"` | Configure passbolt default email from name |
 | passboltEnv.plain.EMAIL_TRANSPORT_DEFAULT_HOST | string | `"127.0.0.1"` | Configure passbolt default email host |
 | passboltEnv.plain.EMAIL_TRANSPORT_DEFAULT_PORT | int | `587` | Configure passbolt default email service port |
+| passboltEnv.plain.EMAIL_TRANSPORT_DEFAULT_TIMEOUT | int | `30` | Configure passbolt default email timeout |
 | passboltEnv.plain.EMAIL_TRANSPORT_DEFAULT_TLS | bool | `true` | Toggle passbolt tls |
 | passboltEnv.plain.KUBECTL_DOWNLOAD_CMD | string | `"curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl\""` | Download Command for kubectl |
 | passboltEnv.plain.PASSBOLT_JWT_SERVER_KEY | string | `"/var/www/passbolt/config/jwt/jwt.key"` | Configure passbolt jwt private key path |

--- a/tests/values-test.yaml
+++ b/tests/values-test.yaml
@@ -136,8 +136,12 @@ passboltEnv:
     PASSBOLT_PLUGINS_LICENSE_LICENSE: /etc/passbolt/subscription_key.txt
     # -- Configure passbolt default email from
     EMAIL_DEFAULT_FROM: no-reply@passbolt.local
+    # -- Configure passbolt default email from name
+    EMAIL_DEFAULT_FROM_NAME: Passbolt
     # -- Configure passbolt default email host
     EMAIL_TRANSPORT_DEFAULT_HOST: 127.0.0.1
+    # -- Configure passbolt default email timeout
+    EMAIL_TRANSPORT_DEFAULT_TIMEOUT: 30
     # -- Toggle passbolt tls
     EMAIL_TRANSPORT_DEFAULT_TLS: true
     # -- Configure passbolt jwt private key path

--- a/values.yaml
+++ b/values.yaml
@@ -206,8 +206,12 @@ passboltEnv:
     PASSBOLT_PLUGINS_LICENSE_LICENSE: /etc/passbolt/subscription_key.txt
     # -- Configure passbolt default email from
     EMAIL_DEFAULT_FROM: no-reply@passbolt.local
+    # -- Configure passbolt default email from name
+    EMAIL_DEFAULT_FROM_NAME: Passbolt
     # -- Configure passbolt default email host
     EMAIL_TRANSPORT_DEFAULT_HOST: 127.0.0.1
+    # -- Configure passbolt default email timeout
+    EMAIL_TRANSPORT_DEFAULT_TIMEOUT: 30
     # -- Toggle passbolt tls
     EMAIL_TRANSPORT_DEFAULT_TLS: true
     # -- Configure passbolt jwt private key path


### PR DESCRIPTION
This adds two new values in the `passboltEnv.plain` key for setting up the sender name for emails (`EMAIL_DEFAULT_FROM_NAME`) and the timeout for the email transport (`EMAIL_TRANSPORT_DEFAULT_TIMEOUT`), instead of having to pass extra env variables.