### PR TITLE
feat: add value for supplying an existing secret containing the GPG server keypair

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ chart and deletes the release.
 | fullnameOverride | string | `""` | Value to override the whole fullName |
 | global.imagePullSecrets | list | `[]` |  |
 | global.imageRegistry | string | `""` |  |
+| gpgExistingSecret | string | `""` | Name of the existing secret for the GPG server keypair. The secret must contain the `serverkey.asc` and `serverkey_private.asc` keys. |
 | gpgPath | string | `"/etc/passbolt/gpg"` | Configure passbolt gpg directory |
 | gpgServerKeyPrivate | string | `""` | Gpg server private key in base64 |
 | gpgServerKeyPublic | string | `""` | Gpg server public key in base64 |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -87,7 +87,7 @@ Show error message if the user didn't set the needed values during upgrade
 {{- $arguments := "" }}
 {{- $message := "" -}}
 {{- $header := "" -}}
-{{ if and $.Release.IsUpgrade (or ( not $.Values.gpgServerKeyPublic ) ( not $.Values.gpgServerKeyPrivate )) }}
+{{ if and $.Release.IsUpgrade ( not $.Values.gpgExistingSecret ) (or ( not $.Values.gpgServerKeyPublic ) ( not $.Values.gpgServerKeyPrivate )) }}
 {{- $secretName := printf "%s-%s-%s" (include "passbolt-library.fullname" . ) "sec" "gpg" -}}
 {{- $dpName := printf "%s-%s-%s" (include "passbolt-library.fullname" . ) "depl" "srv" -}}
 {{- $containerName := printf "%s-%s-%s" (include "passbolt-library.fullname" . ) "depl" "srv" -}}
@@ -214,3 +214,11 @@ imagePullSecrets:
 {{- end -}}
 {{- printf "%s" $client }}
 {{- end -}}
+
+{{- define "passbolt.gpg.secretName" -}}
+{{- if .Values.gpgExistingSecret -}}
+  {{- printf "%s" .Values.gpgExistingSecret -}}
+{{- else }}
+  {{- printf "%s-sec-gpg" .name -}}
+{{- end }}
+{{- end }}

--- a/templates/cronjob-proc-email.yaml
+++ b/templates/cronjob-proc-email.yaml
@@ -59,7 +59,7 @@ spec:
               volumeMounts:
                 - name: {{ $Name }}-vol-success
                   mountPath: /tmp/pod
-                - name: {{ $Name }}-sec-gpg
+                - name: {{ include "passbolt.gpg.secretName" ( dict "name" $Name "Values" $.Values ) }}
                   mountPath: {{ .Values.gpgPath }}
                   readOnly: true
             {{- if .Values.app.cache.redis.sentinelProxy.enabled }}
@@ -90,9 +90,9 @@ spec:
             - name: {{ $fullName }}-sec-gcs
               secret:
                 secretName: {{ $Name }}-sec-gcs
-            - name: {{ $Name }}-sec-gpg
+            - name: {{ include "passbolt.gpg.secretName" ( dict "name" $Name "Values" $.Values ) }}
               secret:
-                secretName: {{ $Name }}-sec-gpg
+                secretName: {{ include "passbolt.gpg.secretName" ( dict "name" $Name "Values" $.Values ) }}
             {{- if .Values.app.cache.redis.sentinelProxy.enabled }}
             - name: {{ $fullName }}-sec-redis-proxy
               secret:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -25,7 +25,9 @@ spec:
         {{- end }}
       annotations:
         checksum/sec-env: {{ include (print $.Template.BasePath "/secret-env.yaml") . | sha256sum }}
+        {{ if ( not $.Values.gpgExistingSecret ) }}
         checksum/sec-gpg: {{ include (print $.Template.BasePath "/secret-gpg.yaml") . | sha256sum }}
+        {{- end }}
         checksum/cm-env: {{ include (print $.Template.BasePath "/configmap-env.yaml") . | sha256sum }}
         {{- if .Values.passboltEnv.plain.PASSBOLT_PLUGINS_JWT_AUTHENTICATION_ENABLED }}
         checksum/sec-jwt: {{ include (print $.Template.BasePath "/secret-jwt.yaml") . | sha256sum }}
@@ -46,7 +48,7 @@ spec:
           args:
             - "-c"
             - |
-              set -e 
+              set -e
               client="{{- include "passbolt.databaseClient" . }}"
               {{- if or ( eq .Values.app.database.kind "mysql" ) ( eq .Values.app.database.kind "mariadb" ) }}
               cat <<-EOF > /tmp/defaultsfile.cnf
@@ -137,7 +139,7 @@ spec:
             - mountPath: /etc/ssl/certs/passbolt
               name: {{ $fullName }}-sec-tls
               readOnly: true
-            - name: {{ $fullName }}-sec-gpg
+            - name: {{ include "passbolt.gpg.secretName" ( dict "name" $Name "Values" $.Values ) }}
               mountPath: {{ .Values.gpgPath }}
               readOnly: true
             {{- if .Values.subscriptionKey }}
@@ -184,9 +186,9 @@ spec:
         - name: {{ $fullName }}-sec-tls
           secret:
             secretName: {{ include "passbolt.container.tls.secretName" (dict "name" $Name "ingressTLS" .Values.ingress.tls "globalTLS" $.Values.tls ) }}
-        - name: {{ $fullName }}-sec-gpg
+        - name: {{ include "passbolt.gpg.secretName" ( dict "name" $Name "Values" $.Values ) }}
           secret:
-            secretName: {{ $Name }}-sec-gpg
+            secretName: {{ include "passbolt.gpg.secretName" ( dict "name" $Name "Values" $.Values ) }}
         {{- if .Values.app.cache.redis.enabled }}
         - configMap:
             name: {{ $Name }}-cm-app-php

--- a/templates/job-create-gpg.yaml
+++ b/templates/job-create-gpg.yaml
@@ -1,4 +1,4 @@
-{{- if or ( not .Values.gpgServerKeyPublic ) ( not .Values.gpgServerKeyPrivate ) }}
+{{- if and ( not .Values.gpgExistingSecret ) ( or ( not .Values.gpgServerKeyPublic ) ( not .Values.gpgServerKeyPrivate ) ) }}
 {{- $type := "job" -}}
 {{- $action := "create-gpg-keys" -}}
 {{- $Name := include "passbolt-library.fullname" . -}}
@@ -70,8 +70,8 @@ spec:
               kubectlDownload=${KUBECTL_DOWNLOAD_CMD:-'curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"'}
               eval $kubectlDownload
               chmod +x kubectl
-              ./kubectl patch secret {{ $Name }}-sec-gpg --type='json' -p='[{"op": "replace", "path" : "/data/serverkey_private.asc", "value" : '"${PRIVATE_SERVERKEY}"'}]'
-              ./kubectl patch secret {{ $Name }}-sec-gpg --type='json' -p='[{"op": "replace", "path" : "/data/serverkey.asc", "value" : '"${PUBLIC_SERVERKEY}"'}]'
+              ./kubectl patch secret {{ include "passbolt.gpg.secretName" ( dict "name" $Name "Values" $.Values ) }} --type='json' -p='[{"op": "replace", "path" : "/data/serverkey_private.asc", "value" : '"${PRIVATE_SERVERKEY}"'}]'
+              ./kubectl patch secret {{ include "passbolt.gpg.secretName" ( dict "name" $Name "Values" $.Values ) }} --type='json' -p='[{"op": "replace", "path" : "/data/serverkey.asc", "value" : '"${PUBLIC_SERVERKEY}"'}]'
               touch /tmp/pod/success
               echo "Success"
           env:

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -18,7 +18,7 @@ rules:
   - {{ $Name }}-sec-redis-proxy
   - {{ $Name }}-cm-env
   - {{ $Name }}-sec-env
-  - {{ $Name }}-sec-gpg
+  - {{ include "passbolt.gpg.secretName" ( dict "name" $Name "Values" $.Values ) }}
   - {{ $Name }}-sec-jwt
   - {{ $Name }}-sec-tls
   - {{ $Name }}-sec-tls-ing
@@ -65,7 +65,7 @@ rules:
   resources: [ "configmaps", "secrets" ]
   resourceNames:
   - {{ $Name }}-cm-env
-  - {{ $Name }}-sec-gpg
+  - {{ include "passbolt.gpg.secretName" ( dict "name" $Name "Values" $.Values ) }}
   - {{ $Name }}-sec-env
   - {{ $Name }}-sec-redis-proxy
   verbs: ["get", "patch"]

--- a/templates/secret-gpg.yaml
+++ b/templates/secret-gpg.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.gpgExistingSecret }}
 {{- $type := "sec" -}}
 {{- $action := "gpg" -}}
 {{- $Name := include "passbolt-library.fullname" . -}}
@@ -25,3 +26,4 @@ data:
   {{- else }}
     serverkey.asc: {{ printf "%q" "" }}
   {{- end }}
+{{- end }}

--- a/tests/auto_server_key_creation_test.yaml
+++ b/tests/auto_server_key_creation_test.yaml
@@ -17,13 +17,22 @@ tests:
           kind: Job
           name: test-passbolt-job-create-gpg-keys
 
-  - it: should not create a gpg job
+  - it: should not create a gpg job when key values are supplied
     templates:
       - job-create-gpg.yaml
     set:
       passboltEnv.secret.PASSBOLT_GPG_SERVER_KEY_FINGERPRINT: "test"
       gpgServerKeyPublic: "test"
       gpgServerKeyPrivate: "test"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create a gpg job when an existing secret is supplied
+    templates:
+      - job-create-gpg.yaml
+    set:
+      gpgExistingSecret: "my-gpg-secret"
     asserts:
       - hasDocuments:
           count: 0

--- a/tests/cronjobs_redis_sidecar_test.yaml
+++ b/tests/cronjobs_redis_sidecar_test.yaml
@@ -80,5 +80,28 @@ tests:
           path: spec.jobTemplate.spec.template.spec.volumes
           content:
             name: test-passbolt-sec-gpg
+            secret:
+              secretName: test-passbolt-sec-gpg
+          count: 1
+          any: true
+
+  - it: should use the existing gpg secret if supplied
+    templates:
+      - cronjob-proc-email.yaml
+    set:
+      redis.auth.enabled: true
+      redis.replica.replicaCount: 2
+      autoscaling.enabled: false
+      cleanOrgs: true
+      migrateOldDbs: true
+      enableEmailCron: true
+      gpgExistingSecret: "my-gpg-secret"
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content:
+            name: my-gpg-secret
+            secret:
+              secretName: my-gpg-secret
           count: 1
           any: true

--- a/tests/deployment_gpg_secret_test.yaml
+++ b/tests/deployment_gpg_secret_test.yaml
@@ -1,0 +1,46 @@
+---
+suite: deployment gpg secret
+release:
+  name: test
+values:
+  - values-test.yaml
+tests:
+  - it: should contain a volumes and volumeMounts section for gpg secret
+    templates:
+      - deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test-passbolt-sec-gpg
+          count: 1
+          any: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: test-passbolt-sec-gpg
+            secret:
+              secretName: test-passbolt-sec-gpg
+          count: 1
+          any: true
+
+  - it: should use the existing gpg secret if supplied
+    templates:
+      - deployment.yaml
+    set:
+      gpgExistingSecret: "my-gpg-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: my-gpg-secret
+          count: 1
+          any: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: my-gpg-secret
+            secret:
+              secretName: my-gpg-secret
+          count: 1
+          any: true

--- a/tests/secret_gpg_test.yaml
+++ b/tests/secret_gpg_test.yaml
@@ -1,0 +1,27 @@
+---
+suite: secret gpg
+release:
+  name: test
+values:
+  - values-test.yaml
+tests:
+  - it: should create a gpg secret
+    templates:
+      - secret-gpg.yaml
+    set:
+      gpgExistingSecret: ""
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Secret
+          name: test-passbolt-sec-gpg
+
+  - it: should not create a gpg secret when an existing secret is supplied
+    templates:
+      - secret-gpg.yaml
+    set:
+      gpgExistingSecret: "my-gpg-secret"
+    asserts:
+      - hasDocuments:
+          count: 0
+

--- a/tests/values-test.yaml
+++ b/tests/values-test.yaml
@@ -101,6 +101,8 @@ gpgPath: /etc/passbolt/gpg
 gpgServerKeyPrivate: ""
 # -- Gpg server public key in base64
 gpgServerKeyPublic: ""
+# -- Name of the existing secret for the GPG server keypair. The secret must contain the `serverkey.asc` and `serverkey_private.asc` keys.
+gpgExistingSecret: ""
 
 # -- Configure passbolt jwt directory
 jwtPath: /etc/passbolt/jwt

--- a/values.yaml
+++ b/values.yaml
@@ -167,6 +167,8 @@ gpgPath: /etc/passbolt/gpg
 gpgServerKeyPrivate: ""
 # -- Gpg server public key in base64
 gpgServerKeyPublic: ""
+# -- Name of the existing secret for the GPG server keypair. The secret must contain the `serverkey.asc` and `serverkey_private.asc` keys.
+gpgExistingSecret: ""
 
 # -- Configure passbolt jwt directory
 jwtPath: /etc/passbolt/jwt


### PR DESCRIPTION
This adds a new value, `gpgExistingSecret`, to allow providing an existing secret containing the `serverkey.asc` and `serverkey_private.asc` keys instead of generating those when installing the chart. My use case for this is migrating Passbolt from an old environment to Kubernetes, while keeping the contents of the database and the GPG keypair.

When an existing GPG secret is supplied, the GPG keypair creation job does not run, and the GPG secret is not created by the chart.

Everything (?) has been modified to use the existing secret in place of the normally generated one if one was supplied.

Some ideas for the future:
- Would this also be useful for the JWT keypair?
- The `gpgX` keys (and by extension, the `jwtX` keys too) should be moved to their own sections, such as:
```yml
gpg:
  path: /etc/passbolt/gpg
  existingSecret: ""
  serverPrivateKey: ""
  serverPublicKey: ""
  createJob:
    extraPodLabels: {}

jwt:
  path: /etc/passbolt/jwt
  existingSecret: ""
  forceKeyCreation: false
  serverPrivateKey: ""
  serverPublicKey: ""
  createJob:
    extraPodLabels: {}
```

Please tell me if those ideas seem good.