### PR TITLE
Allow use of alternate postgresql port

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -70,11 +70,11 @@ spec:
               apt update
               apt install -y postgresql-client
               cat <<-EOF > /tmp/.pgpass
-              ${DATASOURCES_DEFAULT_HOST}:5432:*:${DATASOURCES_DEFAULT_USERNAME}:${DATASOURCES_DEFAULT_PASSWORD}
+              ${DATASOURCES_DEFAULT_HOST}:${DATASOURCES_DEFAULT_PORT}:*:${DATASOURCES_DEFAULT_USERNAME}:${DATASOURCES_DEFAULT_PASSWORD}
               EOF
               chmod 600 /tmp/.pgpass
               export PGPASSFILE='/tmp/.pgpass'
-              while ! ${client} -h ${DATASOURCES_DEFAULT_HOST} ; do
+              while ! ${client} -h ${DATASOURCES_DEFAULT_HOST} -p ${DATASOURCES_DEFAULT_PORT} ; do
                 echo "Waiting for postgresql database connection..."
                 sleep 2
               done
@@ -82,6 +82,8 @@ spec:
           env:
             - name: DATASOURCES_DEFAULT_HOST
               value: {{ include "passbolt.databaseServiceName" . }}
+            - name: DATASOURCES_DEFAULT_PORT
+              value: {{ .Values.passboltEnv.plain.DATASOURCES_DEFAULT_PORT | quote }}
             {{- with .Values.passboltEnv.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
Without this change the init container fail when using an alternate port on an externally hosted PostgreSQL cluster.