### PR TITLE
feat: Add Extra Containers Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ chart and deletes the release.
 | app.database.kind | string | `"mariadb"` |  |
 | app.databaseInitContainer | object | `{"enabled":true}` | Configure pasbolt deployment init container that waits for database |
 | app.databaseInitContainer.enabled | bool | `true` | Toggle pasbolt deployment init container that waits for database |
+| app.extraContainers | list | `[]` | Configure extra container to be added to pods |
 | app.extraPodLabels | object | `{}` |  |
 | app.image.pullPolicy | string | `"IfNotPresent"` | Configure pasbolt deployment image pullPolicy |
 | app.image.registry | string | `""` | Configure pasbolt deployment image repsitory |
@@ -269,5 +270,5 @@ and they will be downloaded during the tests execution if they are not installed
 We rely on the [helm-docs](https://github.com/norwoodj/helm-docs) helm plugin and [mdformat](https://github.com/executablebooks/mdformat) with [mdformat-tables](https://github.com/executablebooks/mdformat-tables) to generate and format the README.md on each release
 
 ```
-helm-docs -t README.md.gotmpl --dry-run | mdformat - > README.md 
+helm-docs -t README.md.gotmpl --dry-run | mdformat - > README.md
 ```

--- a/templates/cronjob-proc-email.yaml
+++ b/templates/cronjob-proc-email.yaml
@@ -84,6 +84,9 @@ spec:
               resources:
                 {{- toYaml .Values.redisProxyResources | nindent 16 }}
             {{- end }}
+          {{- if .Values.app.extraContainers }}
+          {{- toYaml .Values.app.extraContainers | nindent 12 }}
+          {{- end }}
           volumes:
             - name: vol-success
               emptyDir: {}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -175,6 +175,9 @@ spec:
           resources:
             {{- toYaml .Values.app.cache.redis.sentinelProxy.resources | nindent 12 }}
         {{- end -}}
+        {{- if .Values.app.extraContainers }}
+        {{- toYaml .Values.app.extraContainers | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -161,6 +161,8 @@ app:
     # @ignored
     autogenerate: true
     #existingSecret: ""
+  # -- Configure additional containers to be added to the pod
+  extraContainers: []
 
 # -- Enable email cron
 cronJobEmail:


### PR DESCRIPTION
Adds support for extra containers to be added to the deployment. This is useful where teams have a need to add a sidecar container alongside the main application. 

For example to use GCP CloudSQL you need to use cloudsqlproxy. 
Usage would be like so 

```
  extraContainers:
    - name: cloud-sql-proxy
      image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.2-alpine
      imagePullPolicy: IfNotPresent
      command:
        - "./cloud-sql-proxy"
        - "foo:europe-west1:bar"
        - "--port"
        - "5432"
        - "--structured-logs"
      ports:
        - containerPort: 5432
          protocol: TCP
        runAsNonRoot: true
      resources:
        limits:
          memory: 48Mi
        requests:
          cpu: 100m
          memory: 32Mi
```