### PR TITLE
Fix haproxy of email job is occupying one CPU core

### DIFF
--- a/templates/cronjob-proc-email.yaml
+++ b/templates/cronjob-proc-email.yaml
@@ -73,7 +73,7 @@ spec:
                 - |
                   haproxy -f /usr/local/etc/haproxy/haproxy.cfg &
                   REDIS_PROXY_PID=$?
-                  while true; do if [ -f "/tmp/pod/success" ]; then kill $REDIS_PROXY_PID; sleep 5;  exit 0; fi; done
+                  while true; do if [ -f "/tmp/pod/success" ]; then kill $REDIS_PROXY_PID; sleep 5; exit 0; else sleep 1; fi; done
               volumeMounts:
                 - name: vol-success
                   mountPath: /tmp/pod


### PR DESCRIPTION
When the email cron job is used with redis sentinelProxy, the bash script ensuring termination of the haproxy sidecar is in an infinite loop. This infinite loop uses up 100% of one CPU core.

By introducing a sleep the CPU usage is eliminated without significantly increasing the job duration (at most 1s).