### PR TITLE
feat: support redis authentication with existing secret

### DIFF
--- a/templates/cronjob-proc-email.yaml
+++ b/templates/cronjob-proc-email.yaml
@@ -83,6 +83,14 @@ spec:
                   readOnly: true
               resources:
                 {{- toYaml .Values.redisProxyResources | nindent 16 }}
+              {{- if and .Values.redis.auth.enabled .Values.redis.auth.existingSecret }}
+              env:
+                - name: REDISPWD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.redis.auth.existingSecret }}
+                      key: {{ .Values.redis.auth.existingSecretPasswordKey }}
+              {{- end -}}
             {{- end }}
           {{- if .Values.app.extraContainers }}
           {{- toYaml .Values.app.extraContainers | nindent 12 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -178,6 +178,14 @@ spec:
               readOnly: true
           resources:
             {{- toYaml .Values.app.cache.redis.sentinelProxy.resources | nindent 12 }}
+          {{- if and .Values.redis.auth.enabled .Values.redis.auth.existingSecret }}
+          env:
+            - name: REDISPWD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redis.auth.existingSecret }}
+                  key: {{ .Values.redis.auth.existingSecretPasswordKey }}
+          {{- end -}}
         {{- end -}}
         {{- if .Values.app.extraContainers }}
         {{- toYaml .Values.app.extraContainers | nindent 8 }}

--- a/templates/secret-redis-proxy.yaml
+++ b/templates/secret-redis-proxy.yaml
@@ -47,10 +47,14 @@ stringData:
       option tcp-check
       tcp-check connect
       {{- if .Values.redis.auth.enabled -}}
+      {{- if .Values.redis.auth.existingSecret }}
+      tcp-check send AUTH\ ${REDISPWD}\r\n
+      {{- else }}
       {{- if .Values.redis.global.redis.password -}}
       tcp-check send AUTH\ {{ .Values.redis.global.redis.password }}\r\n
       {{- else }}
       tcp-check send AUTH\ {{ .Values.redis.auth.password }}\r\n
+      {{- end }}
       {{- end }}
       {{- end }}
       tcp-check send PING\r\n

--- a/templates/secret-redis-proxy.yaml
+++ b/templates/secret-redis-proxy.yaml
@@ -48,7 +48,7 @@ stringData:
       tcp-check connect
       {{- if .Values.redis.auth.enabled -}}
       {{- if .Values.redis.auth.existingSecret }}
-      tcp-check send AUTH\ ${REDISPWD}\r\n
+      tcp-check send "AUTH\ ${REDISPWD}\r\n"
       {{- else }}
       {{- if .Values.redis.global.redis.password -}}
       tcp-check send AUTH\ {{ .Values.redis.global.redis.password }}\r\n


### PR DESCRIPTION
Both the Redis chart dependency and passbolt chart values support providing an existing secret for the Redis credential and passbolt secrets.
However using an existing secret causes the sentinelProxy to fail because it does not consider the `redis.auth.existingSecret` value.

This PR adds support to the sentinelProxy for using an existing secret for the redis authentication by reading it from an environment variable using the haproxy config capability for string interpolation from env vars. 

Context: To support passbolt helm installation using GitOps we cannot store any secrets in the helm values.
Thus any secrets must be stored in existing secrets.
