### PR TITLE
Fix kubectl exec command missing namespace parameter

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -113,7 +113,7 @@ Show error message if the user didn't set the needed values during upgrade
 {{- $header = printf "GPG" -}}
 {{- $message = printf "%s\n%s" $message (printf "  export PRIVATE_KEY=$(kubectl get secret %s --namespace %s -o jsonpath=\"{.data.%s}\")" $secretName $.Release.Namespace "serverkey_private\\.asc") -}}
 {{- $message = printf "%s\n%s" $message (printf "  export PUBLIC_KEY=$(kubectl get secret %s --namespace %s -o jsonpath=\"{.data.%s}\")" $secretName $.Release.Namespace "serverkey\\.asc") -}}
-{{- $message = printf "%s\n%s" $message (printf "  export FINGERPRINT=$(kubectl exec deploy/%s -c %s -- grep PASSBOLT_GPG_SERVER_KEY_FINGERPRINT /etc/environment | awk -F= '{gsub(/\"/, \"\"); print $2}')" $dpName $containerName) -}}
+{{- $message = printf "%s\n%s" $message (printf "  export FINGERPRINT=$(kubectl exec deploy/%s --namespace %s -c %s -- grep PASSBOLT_GPG_SERVER_KEY_FINGERPRINT /etc/environment | awk -F= '{gsub(/\"/, \"\"); print $2}')" $dpName $.Release.Namespace $containerName) -}}
 {{- $arguments = printf "%s %s" $arguments (printf "--set %s=$%s --set %s=$%s --set %s=$%s" "gpgServerKeyPrivate" "PRIVATE_KEY" "gpgServerKeyPublic" "PUBLIC_KEY" "passboltEnv.secret.PASSBOLT_GPG_SERVER_KEY_FINGERPRINT" "FINGERPRINT" ) -}}
 {{- end }}
 {{ if and $.Release.IsUpgrade .Values.passboltEnv.plain.PASSBOLT_PLUGINS_JWT_AUTHENTICATION_ENABLED ( not .Values.jwtCreateKeysForced ) ( not .Values.jwtExistingSecret ) (or ( not $.Values.jwtServerPublic ) ( not $.Values.jwtServerPrivate )) }}
@@ -269,4 +269,3 @@ tls.key: {{ $cert.Key | b64enc }}
 ca.crt: {{ $ca.Cert | b64enc }}
 ca.key: {{ $ca.Key | b64enc }}
 {{- end -}}
-


### PR DESCRIPTION
## Description

The `kubectl exec` command in the helper message template was not including the `--namespace` flag, causing it to default to the current kubectl context namespace instead of using `$.Release.Namespace` like the other kubectl commands in the same helper.

## Problem

When users follow the generated helper instructions, the `kubectl exec` command would fail or execute against the wrong namespace if their current kubectl context was not set to the same namespace where the Helm release was deployed.

## Changes

- Added `--namespace %s` parameter to the `kubectl exec` command in `templates/_helpers.tpl`
- Added corresponding `$.Release.Namespace` template variable to ensure consistency with other kubectl commands in the same helper
